### PR TITLE
implementation of the inherited_args

### DIFF
--- a/t/inherit-arguments.t
+++ b/t/inherit-arguments.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Scalar::Util qw/ refaddr /;
+
+use lib 't/lib';
+
+use Foo;
+
+my $foo = Foo->new( thingy => 'toaster', this => 'stuff' );
+
+is $foo->thingy => 'toaster', '$foo->thingy';
+
+is $foo->bar->thingy => 'toaster', 'thingy() via bar';
+
+is $foo->this => 'stuff', 'this()';
+is $foo->bar->that => 'stuff', 'that()';
+
+is refaddr( $foo->bar->parent ) => refaddr( $foo ), 'parent';

--- a/t/lib/Foo.pm
+++ b/t/lib/Foo.pm
@@ -1,0 +1,14 @@
+package Foo; 
+
+use Moose;
+
+has thingy => ( is => 'ro', );
+has this => ( is => 'ro', );
+
+with 'MooseX::Role::BuildInstanceOf' => {
+    target => 'Foo::Bar',
+    inherited_args => [ qw/ thingy /, { that => 'this', parent => sub { shift } } ],
+};
+
+1;
+

--- a/t/lib/Foo/Bar.pm
+++ b/t/lib/Foo/Bar.pm
@@ -1,0 +1,11 @@
+package Foo::Bar;
+
+use strict;
+use warnings;
+
+use Moose;
+
+has [ qw/ thingy that parent / ] => ( is => 'ro' );
+
+1;
+


### PR DESCRIPTION
Inspiration taken from DBIx::Class::DeploymentHandler::WithApplicatorDumple.
Basically, the goal is to easy off the job of passing some of the attributes
of the master object to its minions.
