### PR TITLE
Fixes RT#90960 Class::MOP::load_class deprecation warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,4 +13,4 @@ github_user = jjn1056
 ; we use autoprereq, but those things below we do not depend on directly
 ; [Prereq]
 ; Moose = 0.92
-; Class::MOP = 0.94
+; Class::Load = 0.20

--- a/lib/MooseX/Role/BuildInstanceOf.pm
+++ b/lib/MooseX/Role/BuildInstanceOf.pm
@@ -2,11 +2,12 @@ package MooseX::Role::BuildInstanceOf;
 # ABSTRACT: Less Boilerplate when you need lots of Instances
 {
     use MooseX::Role::Parameterized 0.13;
+    use Class::Load;
     use 5.008001;
 
     use Moose::Util::TypeConstraints;
     my $ClassName = subtype as 'ClassName';
-    coerce $ClassName, from 'Str', via { Class::MOP::load_class($_); $_ };
+    coerce $ClassName, from 'Str', via { Class::Load::load_class($_); $_ };
 
     my $CodeRef = subtype as 'CodeRef';
     coerce $CodeRef, from 'ArrayRef', via { my $args = $_; sub { $args } };

--- a/t/lib/Album/ResourceTypes.pm
+++ b/t/lib/Album/ResourceTypes.pm
@@ -1,7 +1,7 @@
 package Album::ResourceTypes; {
 
     use Moose;
-    use Class::MOP;
+    use Class::Load;
     use List::MoreUtils qw(uniq);
     use Moose::Util::TypeConstraints;
 
@@ -15,7 +15,7 @@ package Album::ResourceTypes; {
     coerce 'Album.ResourceTypes.ArrayRefOfClassName',
     from 'ArrayRef[Str]',
     via {
-        Class::MOP::load_class($_) for @$_; $_
+        Class::Load::load_class($_) for @$_; $_
     };
 
     has resources => (


### PR DESCRIPTION
This fixes RT#90960: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90960
