### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/02-basic.t
+++ b/t/02-basic.t
@@ -3,8 +3,7 @@ use strict;
 use warnings;
 use lib qw(t/lib);
 
-use_ok 'Album',
-  'No trouble loading the Album class';
+use_ok 'Album';
 
 ok my $album = Album->new(
     storage_args=>[source=>'./t/share'],


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.